### PR TITLE
fix: Use OPENAI_BASE_URL parameter in OpenAI service

### DIFF
--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -1,6 +1,6 @@
 import { config } from '../config';
 
-const OPENAI_API_BASE_URL = 'https://api.openai.com/v1';
+const OPENAI_API_BASE_URL = config.openaiBaseUrl || 'https://api.openai.com/v1';
 
 /**
  * Sends a streaming chat completion request to the OpenAI API via raw fetch


### PR DESCRIPTION
#### Description

Use the configured `OPENAI_BASE_URL` parameter instead of the hard-coded OpenAI API URL.

Closes #1

#### What change does this PR introduce?

Please select the relevant option(s).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

Use the configuration setting in `services/openai.ts`.

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [ ] Relevant comments/docs have been added/updated (for bug fixes/features)